### PR TITLE
DO-1649: replace vim with vim-minimal and drop wget from base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,6 @@ RUN curl -o /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL https://download.postgresql.o
     shared-mime-info \
     sqlite-devel \
     vim-minimal \
-    wget \
     zlib \
     zlib-devel \
     xz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN curl -o /etc/pki/rpm-gpg/PGDG-RPM-GPG-KEY-RHEL https://download.postgresql.o
     ruby-irb \
     shared-mime-info \
     sqlite-devel \
-    vim \
+    vim-minimal \
     wget \
     zlib \
     zlib-devel \


### PR DESCRIPTION
Two debug tools out of the base package list:

- `vim` -> `vim-minimal`. `vim` pulls in `vim-enhanced` and `vim-common`; `vim-minimal` drops both from every downstream service image.
- `wget` removed outright. Nothing depends on the base image's copy. `backend_mys` uses `wget` at build time for the Entrust certs but installs its own, so it is unaffected. The base image's own build steps use `curl`.

Neither is a CVE fix. Base image build 135 (2026-08-04) already patched vim itself. This is attack-surface reduction.

Behaviour change: `vi` stays available, the `vim` binary does not, and `wget` is gone. Anyone exec'ing into a pod will need `vi` and `curl`.

`netcat` is deliberately left in place, so DO-1649's original third item is out of scope. The EPEL `netcat` package owns `/usr/bin/nc` as well as `/usr/bin/netcat`, and 4 of the 9 consumers of this image rely on the base for it. Ticket description updated to match.

Merging builds and pushes a new base image, so downstream services pick this up on their next rebuild.
